### PR TITLE
Allow media picker to use same orientation as it was called from

### DIFF
--- a/Pod/Classes/FSImagePickerController.h
+++ b/Pod/Classes/FSImagePickerController.h
@@ -1,0 +1,13 @@
+//
+//  FSImagePickerController.h
+//  Pods
+//
+//  Created by Tom on 12/23/15.
+//
+//
+
+#import <UIKit/UIKit.h>
+
+@interface FSImagePickerController : UIImagePickerController
+
+@end

--- a/Pod/Classes/FSImagePickerController.m
+++ b/Pod/Classes/FSImagePickerController.m
@@ -1,0 +1,22 @@
+//
+//  FSImagePickerController.m
+//  Pods
+//
+//  Created by Tom on 12/23/15.
+//
+//
+
+#import "FSImagePickerController.h"
+
+@interface FSImagePickerController ()
+
+@end
+
+@implementation FSImagePickerController
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
+    
+    return UIInterfaceOrientationMaskAllButUpsideDown;
+}
+
+@end

--- a/Pod/Classes/FSMediaPicker.h
+++ b/Pod/Classes/FSMediaPicker.h
@@ -10,6 +10,8 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+#import "FSImagePickerController.h"
+
 #ifndef LocalizedStrings
 #define LocalizedStrings(key) \
 NSLocalizedStringFromTableInBundle(key, @"FSMediaPicker", [NSBundle bundleWithPath:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"FSMediaPicker.bundle"]], nil)
@@ -36,7 +38,7 @@ UIKIT_EXTERN NSString const * UIImagePickerControllerCircularEditedImage;
 @required
 - (void)mediaPicker:(FSMediaPicker *)mediaPicker didFinishWithMediaInfo:(NSDictionary *)mediaInfo;
 @optional
-- (void)mediaPicker:(FSMediaPicker *)mediaPicker willPresentImagePickerController:(UIImagePickerController *)imagePicker;
+- (void)mediaPicker:(FSMediaPicker *)mediaPicker willPresentImagePickerController:(FSImagePickerController *)imagePicker;
 - (void)mediaPickerDidCancel:(FSMediaPicker *)mediaPicker;
 
 @end
@@ -48,13 +50,14 @@ UIKIT_EXTERN NSString const * UIImagePickerControllerCircularEditedImage;
 
 @property (assign, nonatomic) id<FSMediaPickerDelegate> delegate;
 
-@property (copy, nonatomic) void(^willPresentImagePickerBlock)(FSMediaPicker *mediaPicker, UIImagePickerController *imagePicker);
+@property (copy, nonatomic) void(^willPresentImagePickerBlock)(FSMediaPicker *mediaPicker, FSImagePickerController *imagePicker);
 @property (copy, nonatomic) void(^finishBlock)(FSMediaPicker *mediaPicker, NSDictionary *mediaInfo);
 @property (copy, nonatomic) void(^cancelBlock)(FSMediaPicker *mediaPicker);
 
 - (instancetype)initWithDelegate:(id<FSMediaPickerDelegate>)delegate;
 
 - (void)showFromView:(UIView *)view;
+-(void)show;
 
 @end
 
@@ -107,7 +110,7 @@ UIKIT_EXTERN NSString const * UIImagePickerControllerCircularEditedImage;
 
 @end
 
-@interface UIImagePickerController (FSMediaPicker)
+@interface FSImagePickerController (FSMediaPicker)
 
 @property (strong, nonatomic) FSMediaPicker *mediaPicker;
 

--- a/Pod/Classes/FSMediaPicker.m
+++ b/Pod/Classes/FSMediaPicker.m
@@ -12,7 +12,7 @@
 #import <objc/runtime.h>
 
 #define LocalizedString(key) \
-NSLocalizedStringWithDefaultValue(key, @"FSMediaPicker", [NSBundle bundleWithPath:[[[NSBundle mainBundle] bundlePath] stringByAppendingPathComponent:@"FSMediaPicker.bundle"]], key, nil)
+NSLocalizedStringFromTableInBundle(key, @"FSMediaPicker", [NSBundle bundleWithPath:[[[NSBundle mainBundle] bundlePath] stringByAppendingPathComponent:@"FSMediaPicker.bundle"]], nil)
 
 #define kTakePhotoString LocalizedString(@"Take photo")
 #define kSelectPhotoFromLibraryString LocalizedString(@"Select photo from photo library")
@@ -28,7 +28,7 @@ NSString const * UIImagePickerControllerCircularEditedImage = @" UIImagePickerCo
 - (UIViewController *)currentVisibleController;
 
 - (void)delegatePerformFinishWithMediaInfo:(NSDictionary *)mediaInfo;
-- (void)delegatePerformWillPresentImagePicker:(UIImagePickerController *)imagePicker;
+- (void)delegatePerformWillPresentImagePicker:(FSImagePickerController *)imagePicker;
 - (void)delegatePerformCancel;
 
 - (void)showAlertController:(UIView *)view;
@@ -122,15 +122,15 @@ NSString const * UIImagePickerControllerCircularEditedImage = @" UIImagePickerCo
     }
 }
 
-#pragma mark - UIImagePickerController Delegate
+#pragma mark - UIImagePickerControllerDelegate
 
-- (void)imagePickerController:(UIImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary *)info
+- (void)imagePickerController:(FSImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary *)info
 {
     [picker.presentingViewController dismissViewControllerAnimated:YES completion:nil];
     [self delegatePerformFinishWithMediaInfo:info];
 }
 
-- (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker
+- (void)imagePickerControllerDidCancel:(FSImagePickerController *)picker
 {
     [picker.presentingViewController dismissViewControllerAnimated:YES completion:nil];
     [self delegatePerformCancel];
@@ -232,7 +232,7 @@ NSString const * UIImagePickerControllerCircularEditedImage = @" UIImagePickerCo
     }
 }
 
-- (void)delegatePerformWillPresentImagePicker:(UIImagePickerController *)imagePicker
+- (void)delegatePerformWillPresentImagePicker:(FSImagePickerController *)imagePicker
 {
     if (_willPresentImagePickerBlock) {
         _willPresentImagePickerBlock(self,imagePicker);
@@ -342,8 +342,8 @@ NSString const * UIImagePickerControllerCircularEditedImage = @" UIImagePickerCo
 
 - (void)takePhotoFromCamera
 {
-    if ([UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]) {
-        UIImagePickerController *imagePicker = [UIImagePickerController new];
+    if ([FSImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]) {
+        FSImagePickerController *imagePicker = [FSImagePickerController new];
         imagePicker.allowsEditing = _editMode != FSEditModeNone;
         imagePicker.delegate = self;
         imagePicker.sourceType = UIImagePickerControllerSourceTypeCamera;
@@ -356,8 +356,8 @@ NSString const * UIImagePickerControllerCircularEditedImage = @" UIImagePickerCo
 
 - (void)takePhotoFromPhotoLibrary
 {
-    if ([UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypePhotoLibrary]) {
-        UIImagePickerController *imagePicker = [UIImagePickerController new];
+    if ([FSImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypePhotoLibrary]) {
+        FSImagePickerController *imagePicker = [FSImagePickerController new];
         imagePicker.allowsEditing = _editMode != FSEditModeNone;
         imagePicker.delegate = self;
         imagePicker.sourceType = UIImagePickerControllerSourceTypePhotoLibrary;
@@ -370,8 +370,8 @@ NSString const * UIImagePickerControllerCircularEditedImage = @" UIImagePickerCo
 
 - (void)takeVideoFromCamera
 {
-    if ([UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]) {
-        UIImagePickerController *imagePicker = [UIImagePickerController new];
+    if ([FSImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]) {
+        FSImagePickerController *imagePicker = [FSImagePickerController new];
         imagePicker.allowsEditing = _editMode != FSEditModeNone;
         imagePicker.delegate = self;
         imagePicker.sourceType = UIImagePickerControllerSourceTypeCamera;
@@ -384,8 +384,8 @@ NSString const * UIImagePickerControllerCircularEditedImage = @" UIImagePickerCo
 
 - (void)takeVideoFromPhotoLibrary
 {
-    if ([UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypePhotoLibrary]) {
-        UIImagePickerController *imagePicker = [UIImagePickerController new];
+    if ([FSImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypePhotoLibrary]) {
+        FSImagePickerController *imagePicker = [FSImagePickerController new];
         imagePicker.allowsEditing = _editMode != FSEditModeNone;
         imagePicker.delegate = self;
         imagePicker.sourceType = UIImagePickerControllerSourceTypePhotoLibrary;
@@ -537,7 +537,7 @@ const char * mediaPickerKey;
 
 @end
 
-@implementation UIImagePickerController (FSMediaPicker)
+@implementation FSImagePickerController (FSMediaPicker)
 
 - (void)setMediaPicker:(FSMediaPicker *)mediaPicker
 {


### PR DESCRIPTION
This PR addresses Issues #6 and #7 that I opened earlier.

This PR opens the FSMediaPicker in the same orientation from which it was called.  This is done by subclassing UIImagePickerController to FSImagePickerController and adding:

```
- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
    return UIInterfaceOrientationMaskAllButUpsideDown;
}
```
